### PR TITLE
Long hold pause/set to toggle speedup (#114)

### DIFF
--- a/Core/Inc/porting/common.h
+++ b/Core/Inc/porting/common.h
@@ -33,3 +33,37 @@ extern int16_t audiobuffer_emulator[AUDIO_BUFFER_LENGTH] __attribute__((section 
 extern int16_t audiobuffer_dma[AUDIO_BUFFER_LENGTH * 2] __attribute__((section (".audio")));
 
 extern const uint8_t volume_tbl[ODROID_AUDIO_VOLUME_MAX + 1];
+
+bool common_emu_frame_loop(void);
+void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choice_t *game_options);
+
+typedef struct {
+    uint last_busy;
+    uint busy_ms;
+    uint sleep_ms;
+} cpumon_stats_t;
+extern cpumon_stats_t cpumon_stats;
+
+/**
+ * Just calls `__WFI()` and measures time spent sleeping.
+ */
+void cpumon_sleep(void);
+void cpumon_reset(void);
+
+/**
+ * Holds common higher-level emu options that need to be used at not-neat
+ * locations in each emulator.
+ *
+ * There should only be one of these objects instantiated.
+ */
+typedef struct {
+    uint32_t last_sync_time;
+    uint16_t skipped_frames;
+    int16_t frame_time_10us;
+    uint8_t skip_frames:1;
+    uint8_t pause_frames:1;
+    uint8_t pause_after_frames:3;
+    uint8_t startup_frames:2;
+} common_emu_state_t;
+
+extern common_emu_state_t common_emu_state;

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -14,6 +14,8 @@
 #include "gw_lcd.h"
 #include "gw_linker.h"
 
+cpumon_stats_t cpumon_stats = {0};
+
 uint32_t audioBuffer[AUDIO_BUFFER_LENGTH];
 uint32_t audio_mute;
 
@@ -66,4 +68,211 @@ void odroid_audio_mute(bool mute)
     }
 
     audio_mute = mute;
+}
+
+common_emu_state_t common_emu_state = {
+    .frame_time_10us = 100000 / 60,  // Most (all?) emus are 60fps
+};
+
+
+/**
+ * Call this each time a frame is drawn.
+ *
+ * Currently assumes that framerate is 60 fps.
+ *
+ * Emu responsibilities:
+ *    * increment `common_emu_state.skip_frames` if a frame came in too slow.
+ * @returns bool Whether or not to draw the frame.
+ */
+bool common_emu_frame_loop(void){
+    rg_app_desc_t *app = odroid_system_get_app();
+    static int32_t frame_integrator = 0;
+    int16_t frame_time_10us = common_emu_state.frame_time_10us;
+    int16_t elapsed_10us = 100 * get_elapsed_time_since(common_emu_state.last_sync_time);
+    bool draw_frame = !common_emu_state.skip_frames;
+
+    odroid_system_tick(!draw_frame, 0, cpumon_stats.busy_ms);
+    cpumon_reset();
+
+    common_emu_state.pause_frames = 0;
+    if(!draw_frame) common_emu_state.skip_frames = 0;
+
+    common_emu_state.last_sync_time = get_elapsed_time();
+
+    if(common_emu_state.startup_frames < 3) {
+        common_emu_state.startup_frames++;
+        return true;
+    }
+
+    switch(app->speedupEnabled){
+        case SPEEDUP_0_5x:
+            frame_time_10us *= 2;
+            break;
+        case SPEEDUP_0_75x:
+            frame_time_10us *= 5;
+            frame_time_10us /= 4;
+            break;
+        case SPEEDUP_1_25x:
+            frame_time_10us *= 4;
+            frame_time_10us /= 5;
+            break;
+        case SPEEDUP_1_5x:
+            frame_time_10us *= 2;
+            frame_time_10us /= 3;
+            break;
+        case SPEEDUP_2x:
+            frame_time_10us /= 2;
+            break;
+        case SPEEDUP_3x:
+            frame_time_10us /= 3;
+            break;
+    }
+    frame_integrator += (elapsed_10us - frame_time_10us);
+    if(frame_integrator > frame_time_10us) common_emu_state.skip_frames = 1;
+    else if(frame_integrator < -frame_time_10us) common_emu_state.pause_frames = 1;
+    common_emu_state.skipped_frames += common_emu_state.skip_frames;
+
+    return draw_frame;
+}
+
+
+
+/**
+ * Common input/macro/menuing features inside all emu loops. This is to be called
+ * after inputs are read into `joystick`, but before the actual emulation tick
+ * is called.
+ *
+ */
+void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choice_t *game_options) {
+    rg_app_desc_t *app = odroid_system_get_app();
+    static emu_speedup_t last_speedup = SPEEDUP_1_5x;
+    static int8_t last_key = -1;
+    static bool pause_pressed = false;
+    static bool macro_activated = false;
+
+    if(joystick->values[ODROID_INPUT_VOLUME]){  // PAUSE/SET button
+        // PAUSE/SET has been pressed, checking additional inputs for macros
+        pause_pressed = true;
+        if(last_key < 0) {
+            if (joystick->values[ODROID_INPUT_POWER]){
+                // Do NOT save-state and then poweroff
+                last_key = ODROID_INPUT_POWER;
+                HAL_SAI_DMAStop(&hsai_BlockA1);
+                odroid_system_sleep();
+            }
+            else if(joystick->values[ODROID_INPUT_START]){ // GAME button
+                // Reserved for future use
+                last_key = ODROID_INPUT_START;
+            }
+            else if(joystick->values[ODROID_INPUT_SELECT]){ // TIME button
+                // Toggle Speedup
+                last_key = ODROID_INPUT_SELECT;
+                if(app->speedupEnabled == SPEEDUP_1x) {
+                    app->speedupEnabled = last_speedup;
+                }
+                else {
+                    last_speedup = app->speedupEnabled;
+                    app->speedupEnabled = SPEEDUP_1x;
+                }
+            }
+            else if(joystick->values[ODROID_INPUT_LEFT]){
+                // Volume Up
+                last_key = ODROID_INPUT_LEFT;
+                int8_t level = odroid_audio_volume_get();
+                if (level > ODROID_AUDIO_VOLUME_MIN) odroid_audio_volume_set(--level);
+            }
+            else if(joystick->values[ODROID_INPUT_RIGHT]){
+                // Volume Down
+                last_key = ODROID_INPUT_RIGHT;
+                int8_t level = odroid_audio_volume_get();
+                if (level < ODROID_AUDIO_VOLUME_MAX) odroid_audio_volume_set(++level);
+            }
+            else if(joystick->values[ODROID_INPUT_UP]){
+                // Brightness Up
+                last_key = ODROID_INPUT_UP;
+                int8_t level = odroid_display_get_backlight();
+                if (level < ODROID_BACKLIGHT_LEVEL_COUNT - 1) odroid_display_set_backlight(++level);
+            }
+            else if(joystick->values[ODROID_INPUT_DOWN]){
+                // Brightness Down
+                last_key = ODROID_INPUT_DOWN;
+                int8_t level = odroid_display_get_backlight();
+                if (level > 0) odroid_display_set_backlight(--level);
+            }
+            else if(joystick->values[ODROID_INPUT_A]){
+                // Save State
+                last_key = ODROID_INPUT_A;
+                odroid_audio_mute(true);
+                odroid_system_emu_save_state(0);
+                odroid_audio_mute(false);
+                common_emu_state.startup_frames = 0;
+            }
+            else if(joystick->values[ODROID_INPUT_B]){
+                // Load State
+                last_key = ODROID_INPUT_B;
+                odroid_system_emu_load_state(0);
+                common_emu_state.startup_frames = 0;
+            }
+        }
+
+        if (last_key >= 0) {
+            macro_activated = true;
+            if (!joystick->values[last_key]) {
+                last_key = -1;
+            }
+
+            // Consume all inputs so it doesn't get passed along to the
+            // running emulator
+            memset(joystick, '\x00', sizeof(odroid_gamepad_state_t));
+        }
+
+    }
+    else if (pause_pressed && !joystick->values[ODROID_INPUT_VOLUME] && !macro_activated){
+        // PAUSE/SET has been released without performing any macro. Launch menu
+        pause_pressed = false;
+
+        odroid_overlay_game_menu(game_options);
+        memset(framebuffer1, 0x0, sizeof(framebuffer1));
+        memset(framebuffer2, 0x0, sizeof(framebuffer2));
+        common_emu_state.startup_frames = 0;
+        cpumon_stats.last_busy = 0;
+    }
+    else if (!joystick->values[ODROID_INPUT_VOLUME]){
+        pause_pressed = false;
+        macro_activated = false;
+        last_key = -1;
+    }
+
+    if (joystick->values[ODROID_INPUT_POWER]) {
+        // Save-state and poweroff
+        HAL_SAI_DMAStop(&hsai_BlockA1);
+        app->saveState("");
+        odroid_system_sleep();
+    }
+
+    if (common_emu_state.pause_after_frames > 0) {
+        (common_emu_state.pause_after_frames)--;
+        if (common_emu_state.pause_after_frames == 0) {
+            pause_pressed = true;
+        }
+    }
+}
+
+void cpumon_sleep(void){
+    uint t0 = get_elapsed_time();
+    if(cpumon_stats.last_busy){
+        cpumon_stats.busy_ms += t0 - cpumon_stats.last_busy;
+    }
+    else{
+        cpumon_stats.busy_ms = 0;
+    }
+    __WFI();
+    uint t1 = get_elapsed_time();
+    cpumon_stats.last_busy = t1;
+    cpumon_stats.sleep_ms += t1 - t0;
+}
+
+void cpumon_reset(void){
+    cpumon_stats.busy_ms = 0;
+    cpumon_stats.sleep_ms = 0;
 }

--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -40,9 +40,6 @@ static odroid_video_frame_t update1 = {GB_WIDTH, GB_HEIGHT, GB_WIDTH * 2, 2, 0xF
 static odroid_video_frame_t update2 = {GB_WIDTH, GB_HEIGHT, GB_WIDTH * 2, 2, 0xFF, -1, NULL, NULL, 0, {}};
 static odroid_video_frame_t *currentUpdate = &update1;
 
-static bool fullFrame = false;
-static uint skipFrames = 0;
-
 static bool saveSRAM = false;
 static int  saveSRAM_Timer = 0;
 
@@ -56,7 +53,6 @@ static void netplay_callback(netplay_event_t event, void *arg)
 
 #define WIDTH 320
 
-static uint32_t skippedFrames = 0;
 
 
 __attribute__((optimize("unroll-loops")))
@@ -70,9 +66,9 @@ static inline void screen_blit(void) {
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, delta, frames, skippedFrames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
         frames = 0;
-        skippedFrames = 0;
+        common_emu_state.skipped_frames = 0;
         lastFPSTime = currentTime;
     }
 
@@ -121,9 +117,9 @@ static void screen_blit_bilinear(void) {
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, delta, frames, skippedFrames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
         frames = 0;
-        skippedFrames = 0;
+        common_emu_state.skipped_frames = 0;
         lastFPSTime = currentTime;
     }
 
@@ -182,9 +178,9 @@ static inline void screen_blit_v3to5(void) {
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, delta, frames, skippedFrames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
         frames = 0;
-        skippedFrames = 0;
+        common_emu_state.skipped_frames = 0;
         lastFPSTime = currentTime;
     }
 
@@ -245,9 +241,9 @@ static inline void screen_blit_jth(void) {
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, delta, frames, skippedFrames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
         frames = 0;
-        skippedFrames = 0;
+        common_emu_state.skipped_frames = 0;
         lastFPSTime = currentTime;
     }
 
@@ -542,21 +538,14 @@ rg_app_desc_t * init(uint8_t load_state)
 
 void app_main_gb(uint8_t load_state, uint8_t start_paused)
 {
-    rg_app_desc_t *app = init(load_state);
+    init(load_state);
     odroid_gamepad_state_t joystick;
-    uint8_t pause_after_frames;
-    uint8_t frames_since_last_skip = 0;
-    uint8_t pauseFrames = 0;
-    uint8_t pause_pressed = 0;
-    uint8_t power_pressed = 0;
-
-    const int frameTime = get_frame_time(60);
 
     if (start_paused) {
-        pause_after_frames = 2;
+        common_emu_state.pause_after_frames = 2;
         odroid_audio_mute(true);
     } else {
-        pause_after_frames = 0;
+        common_emu_state.pause_after_frames = 0;
     }
 
     while (true)
@@ -565,11 +554,13 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused)
 
         odroid_input_read_gamepad(&joystick);
 
-        uint startTime = get_elapsed_time();
-        bool drawFrame = !skipFrames;
-
-        if(drawFrame) frames_since_last_skip += 1;
-        else frames_since_last_skip = 0;
+        bool drawFrame = common_emu_frame_loop();
+        odroid_dialog_choice_t options[] = {
+            {300, "Palette", "7/7", !hw.cgb, &palette_update_cb},
+            // {301, "More...", "", 1, &advanced_settings_cb},
+            ODROID_DIALOG_CHOICE_LAST
+        };
+        common_emu_input_loop(&joystick, options);
 
         pad_set(PAD_UP, joystick.values[ODROID_INPUT_UP]);
         pad_set(PAD_RIGHT, joystick.values[ODROID_INPUT_RIGHT]);
@@ -579,36 +570,6 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused)
         pad_set(PAD_START, joystick.values[ODROID_INPUT_START]);
         pad_set(PAD_A, joystick.values[ODROID_INPUT_A]);
         pad_set(PAD_B, joystick.values[ODROID_INPUT_B]);
-
-        if (pause_pressed != joystick.values[ODROID_INPUT_VOLUME]) {
-            if (pause_pressed) {
-                // TODO: Sync framebuffers in a nicer way
-                lcd_sync();
-
-                odroid_dialog_choice_t options[] = {
-                    {300, "Palette", "7/7", !hw.cgb, &palette_update_cb},
-                    // {301, "More...", "", 1, &advanced_settings_cb},
-                    ODROID_DIALOG_CHOICE_LAST
-                };
-                odroid_overlay_game_menu(options);
-            }
-            pause_pressed = joystick.values[ODROID_INPUT_VOLUME];
-        }
-
-        if (power_pressed != joystick.values[ODROID_INPUT_POWER]) {
-            printf("Power toggle %ld=>%d\n", power_pressed, !power_pressed);
-            power_pressed = joystick.values[ODROID_INPUT_POWER];
-            if (power_pressed) {
-                printf("Power PRESSED %ld\n", power_pressed);
-                HAL_SAI_DMAStop(&hsai_BlockA1);
-                if(!joystick.values[ODROID_INPUT_VOLUME]) {
-                    // Always save as long as PAUSE is not pressed
-                    SaveState("");
-                }
-
-                odroid_system_sleep();
-            }
-        }
 
         emu_run(drawFrame);
 
@@ -627,58 +588,16 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused)
             }
         }
 
-        if (skipFrames == 0)
-        {
-            if (get_elapsed_time_since(startTime) > frameTime) skipFrames = 1;
-            switch(app->speedupEnabled){
-                case SPEEDUP_0_5x:
-                    pauseFrames++;
-                    break;
-                case SPEEDUP_0_75x:
-                    if(frames_since_last_skip % 4 == 0) pauseFrames++;
-                    break;
-                case SPEEDUP_1_25x:
-                    if(frames_since_last_skip % 4 == 0) skipFrames++;
-                    break;
-                case SPEEDUP_1_5x:
-                    if(frames_since_last_skip % 2 == 0) skipFrames++;
-                    break;
-                case SPEEDUP_2x:
-                    skipFrames++;
-                    break;
-                case SPEEDUP_3x:
-                    skipFrames+=2;
-                    break;
-            }
-            skippedFrames += skipFrames;
-        }
-        else if (skipFrames > 0)
-        {
-            skipFrames--;
-        }
-
-        // Tick before submitting audio/syncing
-        odroid_system_tick(!drawFrame, fullFrame, get_elapsed_time_since(startTime));
-
         if(drawFrame)
         {
             // odroid_audio_submit(pcm.buf, pcm.pos >> 1);
             // handled in pcm_submit instead.
             static dma_transfer_state_t last_dma_state = DMA_TRANSFER_STATE_HF;
-            for(uint8_t p = 0; p < pauseFrames + 1; p++) {
+            for(uint8_t p = 0; p < common_emu_state.pause_frames + 1; p++) {
                 while (dma_state == last_dma_state) {
-                    __NOP();
+                    cpumon_sleep();
                 }
                 last_dma_state = dma_state;
-            }
-            pauseFrames = 0;
-        }
-
-        // Render frames before faking a pause button press
-        if (pause_after_frames > 0) {
-            pause_after_frames--;
-            if (pause_after_frames == 0) {
-                pause_pressed = 1;
             }
         }
     }

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -30,10 +30,6 @@
 #define blit blit_5to6
 #endif
 
-static uint8_t pause_after_frames;
-
-static bool fullFrame = 0;
-static uint frameTime = 1000 / 60;
 static uint samplesPerFrame;
 static uint32_t vsync_wait_ms = 0;
 
@@ -127,71 +123,28 @@ void osd_setpalette(rgb_t *pal)
 #endif
 }
 
-static uint32_t skippedFrames = 0;
-
 void osd_vsync()
 {
-    static uint32_t lastSyncTime = 0;
-    static uint8_t skipFrames = 0;
-    static uint8_t frames_since_last_skip = 0;
-
     uint32_t t0;
-    uint32_t elapsed = get_elapsed_time_since(lastSyncTime);
-    uint8_t pauseFrames = 0;
-    bool drawFrame = !skipFrames;
-
-    if(drawFrame) frames_since_last_skip += 1;
-    else frames_since_last_skip = 0;
-
-    rg_app_desc_t *app = odroid_system_get_app();
-    if (skipFrames == 0) {
-        if (elapsed > frameTime) skipFrames = 1;
-        switch(app->speedupEnabled){
-             case SPEEDUP_0_5x:
-                 pauseFrames++;
-                 break;
-             case SPEEDUP_0_75x:
-                 if(frames_since_last_skip % 4 == 0) pauseFrames++;
-                 break;
-             case SPEEDUP_1_25x:
-                 if(frames_since_last_skip % 4 == 0) skipFrames++;
-                 break;
-             case SPEEDUP_1_5x:
-                 if(frames_since_last_skip % 2 == 0) skipFrames++;
-                 break;
-             case SPEEDUP_2x:
-                 skipFrames++;
-                 break;
-             case SPEEDUP_3x:
-                 skipFrames+=2;
-                 break;
-        }
-        skippedFrames += skipFrames;
-    } else if (skipFrames > 0) {
-        skipFrames--;
-    }
+    bool draw_frame = common_emu_frame_loop();
 
     nes_audio_submit(nes_getptr()->apu->buffer, nes_getptr()->apu->samples_per_frame);
 
-    // Tick before submitting audio/syncing
-    odroid_system_tick(!nes_getptr()->drawframe, fullFrame, elapsed);
-
-    nes_getptr()->drawframe = (skipFrames == 0);
+    nes_getptr()->drawframe = draw_frame;
 
     // Wait until the audio buffer has been transmitted
     static uint32_t last_dma_counter = 0;
     t0 = get_elapsed_time();
-    if(drawFrame){
-        for(uint8_t p = 0; p < pauseFrames + 1; p++) {
+    if(draw_frame){
+        for(uint8_t p = 0; p < common_emu_state.pause_frames + 1; p++) {
             while (dma_counter == last_dma_counter) {
-                __WFI();
+                cpumon_sleep();
             }
             last_dma_counter = dma_counter;
         }
     }
 
     vsync_wait_ms += get_elapsed_time_since(t0);
-    lastSyncTime = get_elapsed_time();
 }
 
 void nes_audio_submit(int16_t *buffer, int audioSamples)
@@ -397,9 +350,9 @@ void osd_blitscreen(bitmap_t *bmp)
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, frames, delta, skippedFrames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, frames, delta, common_emu_state.skipped_frames);
         frames = 0;
-        skippedFrames = 0;
+        common_emu_state.skipped_frames = 0;
         vsync_wait_ms = 0;
         lastFPSTime = currentTime;
     }
@@ -444,14 +397,20 @@ static bool palette_update_cb(odroid_dialog_choice_t *option, odroid_dialog_even
 
 void osd_getinput(void)
 {
-    static uint8_t pause_pressed;
-    static uint8_t power_pressed;
     uint16 pad0 = 0;
 
     wdog_refresh();
 
     odroid_gamepad_state_t joystick;
     odroid_input_read_gamepad(&joystick);
+
+    odroid_dialog_choice_t options[] = {
+            {100, "Palette", "Default", 1, &palette_update_cb},
+            // {101, "More...", "", 1, &advanced_settings_cb},
+            ODROID_DIALOG_CHOICE_LAST
+    };
+    common_emu_input_loop(&joystick, options);
+
 
     if (joystick.values[ODROID_INPUT_START])  pad0 |= INP_PAD_START;
     if (joystick.values[ODROID_INPUT_SELECT]) pad0 |= INP_PAD_SELECT;
@@ -461,38 +420,6 @@ void osd_getinput(void)
     if (joystick.values[ODROID_INPUT_RIGHT]) pad0 |= INP_PAD_RIGHT;
     if (joystick.values[ODROID_INPUT_A]) pad0 |= INP_PAD_A;
     if (joystick.values[ODROID_INPUT_B]) pad0 |= INP_PAD_B;
-
-    if (pause_pressed != joystick.values[ODROID_INPUT_VOLUME]) {
-        if (pause_pressed) {
-            printf("Pause pressed %ld=>%d\n", audio_mute, !audio_mute);
-
-            odroid_dialog_choice_t options[] = {
-                    {100, "Palette", "Default", 1, &palette_update_cb},
-                    // {101, "More...", "", 1, &advanced_settings_cb},
-                    ODROID_DIALOG_CHOICE_LAST
-            };
-
-            odroid_overlay_game_menu(options);
-            memset(framebuffer1, 0x0, sizeof(framebuffer1));
-            memset(framebuffer2, 0x0, sizeof(framebuffer2));
-        }
-        pause_pressed = joystick.values[ODROID_INPUT_VOLUME];
-    }
-
-    if (power_pressed != joystick.values[ODROID_INPUT_POWER]) {
-        printf("Power toggle %ld=>%d\n", power_pressed, !power_pressed);
-        power_pressed = joystick.values[ODROID_INPUT_POWER];
-        if (power_pressed) {
-            printf("Power PRESSED %ld\n", power_pressed);
-            HAL_SAI_DMAStop(&hsai_BlockA1);
-            if(!joystick.values[ODROID_INPUT_VOLUME]) {
-                SaveState("");
-            }
-
-            odroid_system_sleep();
-        }
-    }
-
 
     // Enable to log button presses
 #if 0
@@ -504,14 +431,6 @@ void osd_getinput(void)
 #endif
 
     input_update(INP_JOYPAD0, pad0);
-
-    // Render frames before faking a pause button press
-    if (pause_after_frames > 0) {
-        pause_after_frames--;
-        if (pause_after_frames == 0) {
-            pause_pressed = 1;
-        }
-    }
 }
 
 size_t osd_getromdata(unsigned char **data)
@@ -592,10 +511,10 @@ int app_main_nes(uint8_t load_state, uint8_t start_paused)
     odroid_system_emu_init(&LoadState, &SaveState, NULL);
 
     if (start_paused) {
-        pause_after_frames = 3;
+        common_emu_state.pause_after_frames = 3;
         odroid_audio_mute(true);
     } else {
-        pause_after_frames = 0;
+        common_emu_state.pause_after_frames = 0;
     }
 
     autoload = load_state;
@@ -606,12 +525,13 @@ int app_main_nes(uint8_t load_state, uint8_t start_paused)
 
     if (ACTIVE_FILE->region == REGION_PAL) {
         nes_region = NES_PAL;
-        frameTime = 1000 / 50;
+        common_emu_state.frame_time_10us = 100000 / 50;
         samplesPerFrame = (AUDIO_SAMPLE_RATE) / 50;
         HAL_SAI_Transmit_DMA(&hsai_BlockA1, (uint8_t *) audiobuffer_dma,  (2 * AUDIO_SAMPLE_RATE) / 50);
     } else {
         nes_region = NES_NTSC;
-        frameTime = 1000 / 60;
+        common_emu_state.frame_time_10us = 100000 / 60;
+        //printf("frame_time_10us: %d\n", common_emu_state.frame_time_10us);
         samplesPerFrame = (AUDIO_SAMPLE_RATE) / 60;
         HAL_SAI_Transmit_DMA(&hsai_BlockA1, (uint8_t *) audiobuffer_dma, (2 * AUDIO_SAMPLE_RATE) / 60);
     }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ Supported emulators:
 - Sega Master System (sms)
 - Sega SG-1000 (sg)
 
+## Controls
+
+Buttons are mapped as you would expect for each emulator. `GAME` is mapped to `START`,
+and `TIME` is mapped to `SELECT`. `PAUSE/SET` brings up the emulator menu.
+
+By default, pressing the power-button while in a game will automatically trigger
+a save-state prior to putting the system to sleep. Note that this WILL overwrite
+the previous save-state for the current game.
+
+### Macros
+
+Holding the `PAUSE/SET` button while pressing other buttons have the following actions:
+
+- `PAUSE/SET` + `TIME` = Toggle speedup between 1x and the last non-1x speed. Defaults to 1.5x.
+- `PAUSE/SET` + `UP` = Brightness up.
+- `PAUSE/SET` + `DOWN` = Brightness down.
+- `PAUSE/SET` + `RIGHT` = Volume up.
+- `PAUSE/SET` + `LEFT` = Volume down.
+- `PAUSE/SET` + `B` = Load state.
+- `PAUSE/SET` + `A` = Save state.
+- `PAUSE/SET` + `POWER` = Poweroff WITHOUT save-stating.
+
 ## How to report issues
 
 :exclamation: Please read this before reporting issues.


### PR DESCRIPTION
* nes long hold pause/set to toggle speedup

* refactor nes common emu loop; need to fix busyTime

* move odroid_system_tick into common loop, fix cpumon

* nes common_emu_loop

* pce common_emu_loop

* sms common_emu_loop

* fix some warnings

* setup pause/set macros; remove speedup based on long-pressing pause/set

* Update readme. Initial Controls section commit

* linting

* mute while macro save-stating