### PR TITLE
fix typo that make compile fail with ZH_TW=1 options

### DIFF
--- a/Core/Src/retro-go/i18n/rg_i18n.c
+++ b/Core/Src/retro-go/i18n/rg_i18n.c
@@ -86,7 +86,7 @@
 #if INCLUDED_ZH_CN == 1
 #include "rg_i18n_zh_cn.c"
 #endif
-#if INCLUDED_ZHT_TW == 1
+#if INCLUDED_ZH_TW == 1
 #include "rg_i18n_zh_tw.c"
 #endif
 #if INCLUDED_KO_KR == 1


### PR DESCRIPTION
when compile with:
make -j12 COVERFLOW=1 JPG_QUALITY=90 CODEPAGE=950 UICODEPAGE=950 ZH_TW=1

for transitional Chinese filename, it will fail because of a typo in the code